### PR TITLE
 libdns/porkbun: Bump libdns version to v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/libdns/porkbun
 
 go 1.20
 
-require github.com/libdns/libdns v0.2.1
+require github.com/libdns/libdns v0.2.2
 
 require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/models.go
+++ b/models.go
@@ -48,7 +48,7 @@ func (record pkbnRecord) toLibdnsRecord(zone string) libdns.Record {
 	return libdns.Record{
 		ID:       record.ID,
 		Name:     libdns.RelativeName(record.Name, LibdnsZoneToPorkbunDomain(zone)),
-		Priority: priority,
+		Priority: uint(priority),
 		TTL:      ttl,
 		Type:     record.Type,
 		Value:    record.Content,


### PR DESCRIPTION
libdns/porkbun: Bump libdns version to v0.2.2

I am building this plugin together with cloudflare. Since cloudflare does an indirect upgrade of the libdns version, the build fails.

This PR fixes the build as single module, or together with cloudflare.
