### PR TITLE
Upgrade to libdns 1.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,9 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
-	"time"
 )
 
 const ApiBase = "https://api.porkbun.com/api/json/v3"

--- a/client.go
+++ b/client.go
@@ -23,12 +23,13 @@ func LibdnsZoneToPorkbunDomain(zone string) string {
 	return strings.TrimSuffix(zone, ".")
 }
 
-// Converts libdns' root name representation to porkbun's
-func CorrectRootName(name string) string {
-	if name == "@" {
+// Converts libdns' name representation to porkbun's
+func LibdnsNameToPorkbunName(name string, zone string) string {
+	relativeName := libdns.RelativeName(name, zone)
+	if relativeName == "@" {
 		return ""
 	} else {
-		return name
+		return relativeName
 	}
 }
 
@@ -64,8 +65,7 @@ func (p *Provider) updateRecords(_ context.Context, zone string, records []libdn
 	var createdRecords []libdns.Record
 
 	for _, record := range records {
-		relativeName := libdns.RelativeName(record.RR().Name, zone)
-		trimmedName := CorrectRootName(relativeName)
+		trimmedName := LibdnsNameToPorkbunName(record.RR().Name, zone)
 		reqBody, err := porkbunRecordPayload(record, &credentials, zone)
 		reqJson, err := json.Marshal(reqBody)
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -23,6 +23,15 @@ func LibdnsZoneToPorkbunDomain(zone string) string {
 	return strings.TrimSuffix(zone, ".")
 }
 
+// Converts libdns' root name representation to porkbun's
+func CorrectRootName(name string) string {
+	if name == "@" {
+		return ""
+	} else {
+		return name
+	}
+}
+
 // CheckCredentials allows verifying credentials work in test scripts
 func (p *Provider) CheckCredentials(_ context.Context) (string, error) {
 	credentialJson, err := json.Marshal(p.getCredentials())
@@ -61,10 +70,7 @@ func (p *Provider) updateRecords(_ context.Context, zone string, records []libdn
 		}
 		ttlInSeconds := int(rr.TTL / time.Second)
 		relativeName := libdns.RelativeName(rr.Name, zone)
-		trimmedName := relativeName
-		if relativeName == "@" {
-			trimmedName = ""
-		}
+		trimmedName := CorrectRootName(relativeName)
 
 		reqBody := pkbnRecordPayload{&credentials, rr.Data, trimmedName, strconv.Itoa(ttlInSeconds), rr.Type}
 		reqJson, err := json.Marshal(reqBody)

--- a/client.go
+++ b/client.go
@@ -64,15 +64,9 @@ func (p *Provider) updateRecords(_ context.Context, zone string, records []libdn
 	var createdRecords []libdns.Record
 
 	for _, record := range records {
-		rr := record.RR()
-		if rr.TTL/time.Second < 600 {
-			rr.TTL = 600 * time.Second
-		}
-		ttlInSeconds := int(rr.TTL / time.Second)
-		relativeName := libdns.RelativeName(rr.Name, zone)
+		relativeName := libdns.RelativeName(record.RR().Name, zone)
 		trimmedName := CorrectRootName(relativeName)
-
-		reqBody := pkbnRecordPayload{&credentials, rr.Data, trimmedName, strconv.Itoa(ttlInSeconds), rr.Type}
+		reqBody, err := porkbunRecordPayload(record, &credentials, zone)
 		reqJson, err := json.Marshal(reqBody)
 		if err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/libdns/porkbun
 
 go 1.20
 
-require github.com/libdns/libdns v0.2.2
+require github.com/libdns/libdns v1.0.0
 
 require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
+github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/integration_test.go
+++ b/integration_test.go
@@ -33,6 +33,18 @@ func createOrGetTestRecord(t *testing.T, provider Provider, zone string) (*libdn
 		ttl := time.Duration(600 * time.Second)
 		testFullName := "libdns_test_record"
 
+		records, err := provider.GetRecords(context.TODO(), zone)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+		for _, rec := range records {
+			if rec.RR().Name == "libdns_test_record" {
+				testRecord = &rec
+				return testRecord, nil
+			}
+		}
+
 		//Create record
 		appendedRecords, err := provider.AppendRecords(context.TODO(), zone, []libdns.Record{
 			libdns.TXT{

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,16 +2,18 @@ package porkbun
 
 import (
 	"context"
-	"github.com/joho/godotenv"
-	"github.com/libdns/libdns"
+	"fmt"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/libdns/libdns"
 )
 
 var records []libdns.Record
-var testRecord libdns.Record
+var testRecord *libdns.Record
 
 func getInitialRecords(t *testing.T, provider Provider, zone string) []libdns.Record {
 	if len(records) == 0 {
@@ -25,51 +27,50 @@ func getInitialRecords(t *testing.T, provider Provider, zone string) []libdns.Re
 	return records
 }
 
-func createOrGetTestRecord(t *testing.T, provider Provider, zone string) libdns.Record {
-	if testRecord.ID == "" {
+func createOrGetTestRecord(t *testing.T, provider Provider, zone string) (*libdns.Record, error) {
+	if testRecord == nil {
 		testValue := "test-value"
 		ttl := time.Duration(600 * time.Second)
-		recordType := "TXT"
 		testFullName := "libdns_test_record"
 
 		//Create record
 		appendedRecords, err := provider.AppendRecords(context.TODO(), zone, []libdns.Record{
-			{
-				Type:  recordType,
-				Name:  testFullName,
-				TTL:   ttl,
-				Value: testValue,
+			libdns.TXT{
+				Name: testFullName,
+				TTL:  ttl,
+				Text: testValue,
 			},
 		})
 
 		if err != nil {
 			t.Error(err)
 			t.Fail()
+			return nil, err
 		}
 
 		if len(appendedRecords) != 1 {
-			t.Errorf("Incorrect amount of records %d created", len(appendedRecords))
+			err = fmt.Errorf("Incorrect amount of records %d created", len(appendedRecords))
+			t.Error(err)
+			return nil, err
+		} else {
+			testRecord = &appendedRecords[0]
 		}
-
-		testRecord = appendedRecords[0]
 	}
 
-	return testRecord
+	return testRecord, nil
 }
 
 func createOrGetRootRecord(t *testing.T, provider Provider, zone string) libdns.Record {
 	testValue := "test-value"
 	ttl := time.Duration(600 * time.Second)
-	recordType := "CNAME"
 	testFullName := "@"
 
 	//Create record
 	appendedRecords, err := provider.AppendRecords(context.TODO(), zone, []libdns.Record{
-		{
-			Type:  recordType,
-			Name:  testFullName,
-			TTL:   ttl,
-			Value: testValue,
+		libdns.CNAME{
+			Name:   testFullName,
+			TTL:    ttl,
+			Target: testValue,
 		},
 	})
 
@@ -126,7 +127,8 @@ func TestProvider_GetRecords(t *testing.T) {
 
 	log.Println("Records fetched:")
 	for _, record := range initialRecords {
-		t.Logf("%s %s (.%s): %s, %s\n", record.ID, record.Name, zone, record.Value, record.Type)
+		rr := record.RR()
+		t.Logf("%s (.%s): %s, %s\n", rr.Name, zone, rr.Data, rr.Type)
 	}
 }
 
@@ -136,7 +138,11 @@ func TestProvider_AppendRecords(t *testing.T) {
 	//Get records
 	initialRecords := getInitialRecords(t, provider, zone)
 
-	createdRecord := createOrGetTestRecord(t, provider, zone)
+	createdRecord, err := createOrGetTestRecord(t, provider, zone)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 	//Get records
 	postCreatedRecords, err := provider.GetRecords(context.TODO(), zone)
 	if err != nil {
@@ -144,10 +150,10 @@ func TestProvider_AppendRecords(t *testing.T) {
 	}
 
 	if len(postCreatedRecords) != len(initialRecords)+1 {
-		t.Errorf("Additional record not created")
+		t.Errorf("Additional record not created. got: %d, wanted: %d\n", len(postCreatedRecords), len(initialRecords)+1)
 	}
 
-	t.Logf("Created record: \n%v\n", createdRecord.ID)
+	t.Logf("Created record: \n%v\n", createdRecord)
 }
 
 func TestProvider_ModifyRootRecord(t *testing.T) {
@@ -167,19 +173,18 @@ func TestProvider_ModifyRootRecord(t *testing.T) {
 		t.Errorf("Additional record not created")
 	}
 
-	t.Logf("Created record: \n%v\n", createdRecord.ID)
+	t.Logf("Created record: \n%v\n", createdRecord)
 
 	updatedTestValue := "updated-test-value"
 	// Update record
-	updatedRecords, err := provider.SetRecords(context.TODO(), zone, []libdns.Record{
-		{
-			ID:    createdRecord.ID,
-			Type:  "CNAME",
-			Name:  "@",
-			TTL:   time.Duration(600 * time.Second),
-			Value: updatedTestValue,
+	records := []libdns.Record{
+		libdns.CNAME{
+			Name:   "@",
+			TTL:    time.Duration(600 * time.Second),
+			Target: updatedTestValue,
 		},
-	})
+	}
+	updatedRecords, err := provider.SetRecords(context.TODO(), zone, records)
 
 	if err != nil {
 		t.Error(err)
@@ -210,21 +215,22 @@ func TestProvider_UpdateRecordsById(t *testing.T) {
 	initialRecords := getInitialRecords(t, provider, zone)
 
 	ttl := time.Duration(600 * time.Second)
-	recordType := "TXT"
 	testFullName := "libdns_test_record"
 
 	//Create record
-	createdRecord := createOrGetTestRecord(t, provider, zone)
+	_, err := createOrGetTestRecord(t, provider, zone)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	updatedTestValue := "updated-test-value"
 	// Update record
 	updatedRecords, err := provider.SetRecords(context.TODO(), zone, []libdns.Record{
-		{
-			ID:    createdRecord.ID,
-			Type:  recordType,
-			Name:  testFullName,
-			TTL:   ttl,
-			Value: updatedTestValue,
+		libdns.TXT{
+			Name: testFullName,
+			TTL:  ttl,
+			Text: updatedTestValue,
 		},
 	})
 
@@ -256,20 +262,22 @@ func TestProvider_UpdateRecordsByLookup(t *testing.T) {
 	initialRecords := getInitialRecords(t, provider, zone)
 
 	ttl := time.Duration(600 * time.Second)
-	recordType := "TXT"
 	testFullName := "libdns_test_record"
 
 	//Create record
-	_ = createOrGetTestRecord(t, provider, zone)
+	_, err := createOrGetTestRecord(t, provider, zone)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	updatedTestValue := "updated-test-value-by-lookup"
 	// Update record
 	updatedRecords, err := provider.SetRecords(context.TODO(), zone, []libdns.Record{
-		{
-			Type:  recordType,
-			Name:  testFullName,
-			TTL:   ttl,
-			Value: updatedTestValue,
+		libdns.TXT{
+			Name: testFullName,
+			TTL:  ttl,
+			Text: updatedTestValue,
 		},
 	})
 
@@ -298,10 +306,15 @@ func TestProvider_DeleteRecords(t *testing.T) {
 	provider, zone := getProvider(t)
 
 	//Create record
-	createdRecord := createOrGetTestRecord(t, provider, zone)
+	createdRecord, err := createOrGetTestRecord(t, provider, zone)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	// Delete record
-	deleteRecords, err := provider.DeleteRecords(context.TODO(), zone, []libdns.Record{createdRecord})
+	deleteRecords, err := provider.DeleteRecords(context.TODO(), zone, []libdns.Record{*createdRecord})
 
 	if err != nil {
 		t.Error(err)

--- a/models.go
+++ b/models.go
@@ -130,8 +130,7 @@ func porkbunRecordPayload(record libdns.Record, credentials *ApiCredentials, zon
 		rr.TTL = 600 * time.Second
 	}
 	ttlInSeconds := int(rr.TTL / time.Second)
-	relativeName := libdns.RelativeName(rr.Name, zone)
-	trimmedName := CorrectRootName(relativeName)
+	trimmedName := LibdnsNameToPorkbunName(rr.Name, zone)
 	var data string
 	switch rec := record.(type) {
 	case libdns.SRV:

--- a/models_test.go
+++ b/models_test.go
@@ -1,0 +1,213 @@
+package porkbun
+
+import (
+	"fmt"
+	"net/netip"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
+func TestPorkbunRecord_ToLibdnsRecord(t *testing.T) {
+	testCases := []struct {
+		porkbunRecord pkbnRecord
+		want          libdns.Record
+	}{
+		// root A record
+		{
+			pkbnRecord{
+				Content: "1.1.1.1",
+				Name:    "example.com",
+				Notes:   "",
+				Prio:    "0",
+				TTL:     "600",
+				Type:    "A",
+			},
+			libdns.Address{
+				Name: "@",
+				TTL:  mustParseDuration("10m"),
+				IP:   netip.MustParseAddr("1.1.1.1"),
+			},
+		},
+		// subdomain A record
+		{
+			pkbnRecord{
+				Content: "1.1.1.2",
+				Name:    "test.example.com",
+				Notes:   "",
+				Prio:    "0",
+				TTL:     "300",
+				Type:    "A",
+			},
+			libdns.Address{
+				Name: "test",
+				TTL:  mustParseDuration("5m"),
+				IP:   netip.MustParseAddr("1.1.1.2"),
+			},
+		},
+		// subdomain CNAME record
+		{
+			pkbnRecord{
+				Content: "target.example.com.",
+				Name:    "test.example.com",
+				Notes:   "",
+				Prio:    "0",
+				TTL:     "300",
+				Type:    "CNAME",
+			},
+			libdns.CNAME{
+				Name:   "test",
+				TTL:    mustParseDuration("5m"),
+				Target: "target.example.com.",
+			},
+		},
+		// SRV record
+		{
+			pkbnRecord{
+				Content: "1 993 imap.example.com",
+				Name:    "_imaps._tcp.example.com",
+				Notes:   "",
+				Prio:    "10",
+				TTL:     "300",
+				Type:    "SRV",
+			},
+			libdns.SRV{
+				Service:   "imaps",
+				Transport: "tcp",
+				Name:      "example.com",
+				TTL:       mustParseDuration("5m"),
+				Priority:  10,
+				Weight:    1,
+				Port:      993,
+				Target:    "imap.example.com",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s %s", tc.porkbunRecord.Type, tc.want.RR().Name), func(t *testing.T) {
+			var err error
+			switch tc.want.(type) {
+			case libdns.Address:
+				err = equalsAddress(tc.porkbunRecord, tc.want.(libdns.Address))
+			case libdns.CNAME:
+				err = equalsCNAME(tc.porkbunRecord, tc.want.(libdns.CNAME))
+			case libdns.SRV:
+				err = equalsSRV(tc.porkbunRecord, tc.want.(libdns.SRV))
+			default:
+				err = fmt.Errorf("unhandled record type: %s", tc.porkbunRecord.Type)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func equalsAddress(porkbunRecord pkbnRecord, want libdns.Address) error {
+	libdnsRecord, err := porkbunRecord.toLibdnsRecord("example.com")
+	if err != nil {
+		return err
+	}
+
+	address, ok := libdnsRecord.(libdns.Address)
+	if !ok {
+		return fmt.Errorf("invalid type returned. wanted libdns.Address, got %v", reflect.TypeOf(libdnsRecord))
+	}
+
+	if address.Name != want.Name {
+		return fmt.Errorf("incorrect name. wanted '%s' got '%s'", want.Name, address.Name)
+	}
+
+	if address.TTL != want.TTL {
+		return fmt.Errorf("incorrect TTL. wanted '%v' got '%v'", want.TTL, address.TTL)
+	}
+
+	if address.IP.String() != want.IP.String() {
+		return fmt.Errorf("incorrect IP. wanted '%v' got '%v'", want.IP, address.IP)
+	}
+
+	return nil
+}
+
+func equalsCNAME(porkbunRecord pkbnRecord, want libdns.CNAME) error {
+	libdnsRecord, err := porkbunRecord.toLibdnsRecord("example.com")
+	if err != nil {
+		return err
+	}
+
+	cname, ok := libdnsRecord.(libdns.CNAME)
+	if !ok {
+		return fmt.Errorf("invalid type returned. wanted libdns.CNAME, got %v", reflect.TypeOf(libdnsRecord))
+	}
+
+	if cname.Name != want.Name {
+		return fmt.Errorf("incorrect name. wanted '%s' got '%s'", want.Name, cname.Name)
+	}
+
+	if cname.TTL != want.TTL {
+		return fmt.Errorf("incorrect TTL. wanted '%v' got '%v'", want.TTL, cname.TTL)
+	}
+
+	if cname.Target != want.Target {
+		return fmt.Errorf("incorrect Target. wanted '%v' got '%v'", want.Target, cname.Target)
+	}
+
+	return nil
+}
+
+func equalsSRV(porkbunRecord pkbnRecord, want libdns.SRV) error {
+	libdnsRecord, err := porkbunRecord.toLibdnsRecord("example.com")
+	if err != nil {
+		return err
+	}
+
+	srv, ok := libdnsRecord.(libdns.SRV)
+	if !ok {
+		return fmt.Errorf("invalid type returned. wanted libdns.SRV, got %v", reflect.TypeOf(libdnsRecord))
+	}
+
+	if srv.Service != want.Service {
+		return fmt.Errorf("incorrect Service. wanted '%s' got '%s'", want.Service, srv.Service)
+	}
+
+	if srv.Transport != want.Transport {
+		return fmt.Errorf("incorrect Transport. wanted '%s' got '%s'", want.Transport, srv.Transport)
+	}
+
+	if srv.Name != want.Name {
+		return fmt.Errorf("incorrect name. wanted '%s' got '%s'", want.Name, srv.Name)
+	}
+
+	if srv.TTL != want.TTL {
+		return fmt.Errorf("incorrect TTL. wanted '%v' got '%v'", want.TTL, srv.TTL)
+	}
+
+	if srv.Priority != want.Priority {
+		return fmt.Errorf("incorrect Priority. wanted '%v' got '%v'", want.Priority, srv.Priority)
+	}
+
+	if srv.Weight != want.Weight {
+		return fmt.Errorf("incorrect Weight. wanted '%v' got '%v'", want.Weight, srv.Weight)
+	}
+
+	if srv.Port != want.Port {
+		return fmt.Errorf("incorrect Port. wanted '%v' got '%v'", want.Port, srv.Port)
+	}
+
+	if srv.Target != want.Target {
+		return fmt.Errorf("incorrect Target. wanted '%v' got '%v'", want.Target, srv.Target)
+	}
+
+	return nil
+}
+
+func mustParseDuration(durationStr string) time.Duration {
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		panic(err)
+	}
+	return duration
+}

--- a/models_test.go
+++ b/models_test.go
@@ -89,13 +89,13 @@ func TestPorkbunRecord_ToLibdnsRecord(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s %s", tc.porkbunRecord.Type, tc.want.RR().Name), func(t *testing.T) {
 			var err error
-			switch tc.want.(type) {
+			switch want := tc.want.(type) {
 			case libdns.Address:
-				err = equalsAddress(tc.porkbunRecord, tc.want.(libdns.Address))
+				err = equalsAddress(tc.porkbunRecord, want)
 			case libdns.CNAME:
-				err = equalsCNAME(tc.porkbunRecord, tc.want.(libdns.CNAME))
+				err = equalsCNAME(tc.porkbunRecord, want)
 			case libdns.SRV:
-				err = equalsSRV(tc.porkbunRecord, tc.want.(libdns.SRV))
+				err = equalsSRV(tc.porkbunRecord, want)
 			default:
 				err = fmt.Errorf("unhandled record type: %s", tc.porkbunRecord.Type)
 			}

--- a/provider.go
+++ b/provider.go
@@ -61,8 +61,7 @@ func (p *Provider) AppendRecords(_ context.Context, zone string, records []libdn
 			rr.TTL = 600 * time.Second
 		}
 		ttlInSeconds := int(rr.TTL / time.Second)
-		relativeName := libdns.RelativeName(rr.Name, zone)
-		trimmedName := CorrectRootName(relativeName)
+		trimmedName := LibdnsNameToPorkbunName(rr.Name, zone)
 
 		reqBody := pkbnRecordPayload{&credentials, rr.Data, trimmedName, strconv.Itoa(ttlInSeconds), rr.Type}
 		reqJson, err := json.Marshal(reqBody)
@@ -128,7 +127,7 @@ func (p *Provider) DeleteRecords(_ context.Context, zone string, records []libdn
 
 		for _, recordToDelete := range queuedDeletes {
 			rr := recordToDelete.RR()
-			trimmedName := CorrectRootName(rr.Name)
+			trimmedName := LibdnsNameToPorkbunName(rr.Name, zone)
 			_, err = MakeApiRequest(fmt.Sprintf("/dns/deleteByNameType/%s/%s/%s", trimmedZone, rr.Type, trimmedName), bytes.NewReader(reqJson), pkbnResponseStatus{})
 			if err != nil {
 				return deletedRecords, err

--- a/provider.go
+++ b/provider.go
@@ -62,10 +62,7 @@ func (p *Provider) AppendRecords(_ context.Context, zone string, records []libdn
 		}
 		ttlInSeconds := int(rr.TTL / time.Second)
 		relativeName := libdns.RelativeName(rr.Name, zone)
-		trimmedName := relativeName
-		if relativeName == "@" {
-			trimmedName = ""
-		}
+		trimmedName := CorrectRootName(relativeName)
 
 		reqBody := pkbnRecordPayload{&credentials, rr.Data, trimmedName, strconv.Itoa(ttlInSeconds), rr.Type}
 		reqJson, err := json.Marshal(reqBody)
@@ -131,10 +128,7 @@ func (p *Provider) DeleteRecords(_ context.Context, zone string, records []libdn
 
 		for _, recordToDelete := range queuedDeletes {
 			rr := recordToDelete.RR()
-			trimmedName := rr.Name
-			if trimmedName == "@" {
-				trimmedName = ""
-			}
+			trimmedName := CorrectRootName(rr.Name)
 			_, err = MakeApiRequest(fmt.Sprintf("/dns/deleteByNameType/%s/%s/%s", trimmedZone, rr.Type, trimmedName), bytes.NewReader(reqJson), pkbnResponseStatus{})
 			if err != nil {
 				return deletedRecords, err

--- a/provider.go
+++ b/provider.go
@@ -40,7 +40,10 @@ func (p *Provider) GetRecords(_ context.Context, zone string) ([]libdns.Record, 
 
 	recs := make([]libdns.Record, 0, len(response.Records))
 	for _, rec := range response.Records {
-		recs = append(recs, rec.toLibdnsRecord(zone))
+		libdnsRec, err := rec.toLibdnsRecord(zone)
+		if err == nil {
+			recs = append(recs, libdnsRec)
+		}
 	}
 	return recs, nil
 }
@@ -53,17 +56,18 @@ func (p *Provider) AppendRecords(_ context.Context, zone string, records []libdn
 	var createdRecords []libdns.Record
 
 	for _, record := range records {
-		if record.TTL/time.Second < 600 {
-			record.TTL = 600 * time.Second
+		rr := record.RR()
+		if rr.TTL/time.Second < 600 {
+			rr.TTL = 600 * time.Second
 		}
-		ttlInSeconds := int(record.TTL / time.Second)
-		relativeName := libdns.RelativeName(record.Name, zone)
+		ttlInSeconds := int(rr.TTL / time.Second)
+		relativeName := libdns.RelativeName(rr.Name, zone)
 		trimmedName := relativeName
 		if relativeName == "@" {
 			trimmedName = ""
 		}
 
-		reqBody := pkbnRecordPayload{&credentials, record.Value, trimmedName, strconv.Itoa(ttlInSeconds), record.Type}
+		reqBody := pkbnRecordPayload{&credentials, rr.Data, trimmedName, strconv.Itoa(ttlInSeconds), rr.Type}
 		reqJson, err := json.Marshal(reqBody)
 		if err != nil {
 			return createdRecords, err
@@ -79,11 +83,6 @@ func (p *Provider) AppendRecords(_ context.Context, zone string, records []libdn
 			return createdRecords, errors.New(fmt.Sprintf("Invalid response status %s", response.Status))
 		}
 
-		// TODO contact support endpoint isn't returning the ID despite it being in their docs. Fetch as a workaround
-		created, err := p.getMatchingRecord(record, zone)
-		if err == nil && len(created) == 1 {
-			record.ID = created[0].ID
-		}
 		createdRecords = append(createdRecords, record)
 	}
 
@@ -97,27 +96,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	var creates []libdns.Record
 	var results []libdns.Record
 	for _, r := range records {
-		if r.ID == "" {
-			// Try fetch record in case we are just missing the ID
-			matches, err := p.getMatchingRecord(r, zone)
-			if err != nil {
-				return nil, err
-			}
-
-			if len(matches) == 0 {
-				creates = append(creates, r)
-				continue
-			}
-
-			if len(matches) > 1 {
-				return nil, fmt.Errorf("unexpectedly found more than 1 record for %v", r)
-			}
-
-			r.ID = matches[0].ID
-			updates = append(updates, r)
-		} else {
-			updates = append(updates, r)
-		}
+		updates = append(updates, r)
 	}
 
 	created, err := p.AppendRecords(ctx, zone, creates)
@@ -143,18 +122,7 @@ func (p *Provider) DeleteRecords(_ context.Context, zone string, records []libdn
 
 	for _, record := range records {
 		var queuedDeletes []libdns.Record
-		if record.ID == "" {
-			// Try fetch record in case we are just missing the ID
-			matches, err := p.getMatchingRecord(record, zone)
-			if err != nil {
-				return deletedRecords, err
-			}
-			for _, rec := range matches {
-				queuedDeletes = append(queuedDeletes, rec)
-			}
-		} else {
-			queuedDeletes = append(queuedDeletes, record)
-		}
+		queuedDeletes = append(queuedDeletes, record)
 
 		reqJson, err := json.Marshal(credentials)
 		if err != nil {
@@ -162,7 +130,12 @@ func (p *Provider) DeleteRecords(_ context.Context, zone string, records []libdn
 		}
 
 		for _, recordToDelete := range queuedDeletes {
-			_, err = MakeApiRequest(fmt.Sprintf("/dns/delete/%s/%s", trimmedZone, recordToDelete.ID), bytes.NewReader(reqJson), pkbnResponseStatus{})
+			rr := recordToDelete.RR()
+			trimmedName := rr.Name
+			if trimmedName == "@" {
+				trimmedName = ""
+			}
+			_, err = MakeApiRequest(fmt.Sprintf("/dns/deleteByNameType/%s/%s/%s", trimmedZone, rr.Type, trimmedName), bytes.NewReader(reqJson), pkbnResponseStatus{})
 			if err != nil {
 				return deletedRecords, err
 			}


### PR DESCRIPTION
Fixes #13

Sorry for the large PR here; I'm not really sure there's a good way to break it up to be honest. At a high-level, here are the changes I've made:

> * [libdns.Record](https://pkg.go.dev/github.com/libdns/libdns@v1.0.0-beta.1#Record) is now an interface type, not a concrete struct.
> * [libdns.RR](https://pkg.go.dev/github.com/libdns/libdns@v1.0.0-beta.1#RR) is a new struct type that closely resembles the previous Record struct.

In most places, I was able to just use the `libdns.RR` type in place of the `libdns.Record` type. One of the changes here though is that there's no longer an `ID` field on the `libdns.RR` type, which means I had to stop using it for Porkbun's API. Luckily, they offer the ability to modify records with  just the record name and type, so I've taken that approach here.

> * There are [many new struct types](https://pkg.go.dev/github.com/libdns/libdns@v1.0.0-beta.1#pkg-index) corresponding to specific DNS RR-types, such as [Address](https://pkg.go.dev/github.com/libdns/libdns@v1.0.0-beta.1#Address) (for A/AAAA), [TXT](https://pkg.go.dev/github.com/libdns/libdns@v1.0.0-beta.1#TXT), [CNAME](https://pkg.go.dev/github.com/libdns/libdns@v1.0.0-beta.1#CNAME), etc. Your methods should return these types instead of RR to make things easier and more reliable for users.

I didn't actually implement _all_ of the record types, just the few I thought might be used by caddy. If you think this is a mistake, I can go back and add support for the remaining record types as well. I think there could be some more tests added, though I had a few thoughts there. Would love to discuss on IRC/mailing list/Matrix/whatever your preferred communication method is.