### PR TITLE
fix: SetRecords needs to support creating too

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,7 +111,7 @@ func MakeApiRequest[T any](endpoint string, body io.Reader, responseType T) (T, 
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		err = errors.New("Invalid http response status, " + string(bodyBytes) + "for endpoint " + endpoint)
+		err = errors.New("Invalid http response status, " + string(bodyBytes) + " for endpoint " + endpoint)
 		return responseType, err
 	}
 

--- a/client.go
+++ b/client.go
@@ -75,7 +75,9 @@ func (p *Provider) updateRecords(_ context.Context, zone string, records []libdn
 		}
 
 		if response.Status != "SUCCESS" {
-			return nil, err
+			return nil, fmt.Errorf(
+				"invalid response status %s %s", response.Status, response.Message,
+			)
 		}
 		createdRecords = append(createdRecords, record)
 	}
@@ -109,7 +111,7 @@ func MakeApiRequest[T any](endpoint string, body io.Reader, responseType T) (T, 
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		err = errors.New("Invalid http response status, " + string(bodyBytes))
+		err = errors.New("Invalid http response status, " + string(bodyBytes) + "for endpoint " + endpoint)
 		return responseType, err
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -121,6 +121,7 @@ func TestProvider_SetRecords(t *testing.T) {
 	}
 
 	_, err := provider.SetRecords(context.TODO(), zone, []libdns.Record{testCases[0], testCases[1]})
+	_, _ = provider.DeleteRecords(context.TODO(), zone, []libdns.Record{testCases[2], testCases[3]})
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- Fixes the SetRecords method not actually supporting creation of missing records
    > [RecordSetter](https://pkg.go.dev/github.com/libdns/libdns#RecordSetter) to set (create or update) records.
    - This requires fetching the existing ones to compare, porkbun has no upsert style endpoint
- Improves the error messaging to flag more information about what endpoint errored
- Improves the integration tests
    - We now test multiple record types (A & TXT for now) for Append/Set
    - We now ensure Set can both create new & modify existing records
    - Each test runs independently of the others to allow more resilient tests
    - Integration tests for domain root are skipped by default, controlled by environment
 