### PR TITLE
feat: Add zone listing functionality to the provider

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,7 +99,7 @@ func (p *Provider) getZones(_ context.Context) ([]libdns.Zone, error) {
 	}
 
 	if response.Status != "SUCCESS" {
-		return nil, errors.New(fmt.Sprintf("Invalid response status %s", response.Status))
+		return nil, fmt.Errorf("Invalid response status %s", response.Status)
 	}
 
 	var zones []libdns.Zone

--- a/integration_test.go
+++ b/integration_test.go
@@ -241,3 +241,22 @@ func TestProvider_DeleteRecords(t *testing.T) {
 
 	t.Logf("Deleted record: \n%v\n", deleteRecords[0])
 }
+
+func TestProvider_ListZones(t *testing.T) {
+	provider, _ := getProvider(t)
+
+	domains, err := provider.ListZones(context.TODO())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(domains) == 0 {
+		t.Fatal("No domains found")
+	}
+
+	for _, domain := range domains {
+		t.Logf("Domain: %s\n", domain)
+	}
+	t.Logf("Found %d domains\n", len(domains))
+}

--- a/models.go
+++ b/models.go
@@ -10,6 +10,18 @@ import (
 	"github.com/libdns/libdns"
 )
 
+type pkbnDomain struct {
+	Domain       string `json:"domain"`
+	Status       string `json:"status"`
+	TLD          string `json:"tld"`
+	CreateDate   string `json:"createDate"`
+	ExpireDate   string `json:"expireDate"`
+	SecurityLock string `json:"securityLock"`
+	WhoisPrivacy string `json:"whoisPrivacy"`
+	AutoRenew    string `json:"autoRenew"`
+	NotLocal     int    `json:"notLocal"`
+}
+
 type pkbnRecord struct {
 	Content string `json:"content"`
 	Name    string `json:"name"`
@@ -32,6 +44,11 @@ type ApiCredentials struct {
 type pkbnResponseStatus struct {
 	Status  string `json:"status"`
 	Message string `json:"message,omitempty"`
+}
+
+type pkbnDomainResponse struct {
+	Status  string       `json:"status"`
+	Domains []pkbnDomain `json:"domains"`
 }
 type pkbnPingResponse struct {
 	pkbnResponseStatus

--- a/provider.go
+++ b/provider.go
@@ -160,10 +160,21 @@ func (p *Provider) DeleteRecords(_ context.Context, zone string, records []libdn
 	return deletedRecords, nil
 }
 
+func (p *Provider) ListZones(ctx context.Context) ([]libdns.Zone, error) {
+	zones, err := p.getZones(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return zones, nil
+}
+
 // Interface guards
 var (
 	_ libdns.RecordGetter   = (*Provider)(nil)
 	_ libdns.RecordAppender = (*Provider)(nil)
 	_ libdns.RecordSetter   = (*Provider)(nil)
 	_ libdns.RecordDeleter  = (*Provider)(nil)
+	_ libdns.ZoneLister     = (*Provider)(nil)
 )


### PR DESCRIPTION
I noticed that libdns also has a ZoneLister interface

https://pkg.go.dev/github.com/libdns/libdns#ZoneLister

- Added listZones to implement `ZoneLister`
- Added integration test for listZones